### PR TITLE
Make 03-sysinfo.j2 idempotent by sorting network interfaces

### DIFF
--- a/templates/03-sysinfo.j2
+++ b/templates/03-sysinfo.j2
@@ -24,7 +24,7 @@ echo "Total: $TOTALMEM / Free: $MEMFREEREAL / Swap: $SWAPUSAGE"
 echo
   {% if ansible_interfaces is defined %}
 echo "Interfaces:"
-  {%   for int in ansible_interfaces %}
+  {%   for int in ansible_interfaces | sort %}
   {%     if "veth" not in int %}
   {%     if "br" not in int %}
 echo " Interface: {{ int }}"


### PR DESCRIPTION
Ansible network interfaces are randomly ordered which prevent generated template 03-sysinfo.j2 from being idempotent.

This PR addresses this by sorting ansible_interfaces as they are iterated through in 03-sysinfo.j2.